### PR TITLE
add link to release and unify the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,45 +1,24 @@
-<!--- Provide a general summary of your changes in the Title above -->
+## Purpose of this pull request
 
-## Description
+This pull request (PR) ...
 
-<!--- Describe your changes in detail -->
+## Affected pages
 
-## Related Issue
+<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->
 
-<!--- This project only accepts pull requests related to open issues -->
-<!--- If suggesting a new feature or change, please discuss it in an issue first -->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
+- ...
 
-## Motivation and Context
+## Links to Commerce code
 
-<!--- Why is this change required? What problem does it solve? -->
+<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED.
+If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add the link here. -->
 
-## How Has This Been Tested?
+- ...
 
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+<!--
+If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
 
-## Screenshots (if appropriate):
+`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
 
-## Types of changes
-
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-
-## Checklist:
-
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-
-- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-- [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
-- [ ] I have read the **CONTRIBUTING** document.
-- [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
+-->

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,9 +15,10 @@ Learn how to deploy Adobe Commerce to a local, cloud-like environment using thes
 
 #### Resources
 
-- [Adobe Commerce on cloud infrastructure guide](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/overview.html)
-- [Adobe Commerce Developer Documentation](https://developer.adobe.com/commerce/docs) (Adobe Developer site)
-- [Adobe Commerce Documentation](https://experienceleague.adobe.com/docs/commerce.html) (Adobe Experience League site)
+- [Commerce on cloud infrastructure guide](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/overview.html)
+- [Cloud tools release notes](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/release-notes/cloud-tools-suite.html)
+- [Commerce Developer Documentation](https://developer.adobe.com/commerce/docs)
+- [Commerce User Documentation](https://experienceleague.adobe.com/docs/commerce.html)
 
 ## Overview
 


### PR DESCRIPTION
This PR:

- updates the Pull Request template to be the same as the one used in the Cloud guide
- updated the landing page Resources to include a link to the Cloud Suite release notes for convenience
- removed the redundant "Adobe" from the link descriptions so the list looks and fits better