### PR TITLE
COMDOX-328: Port 2.4.6-develop changes from magento-commerce/devdocs

### DIFF
--- a/src/pages/docker/configure/configuration-sources.md
+++ b/src/pages/docker/configure/configuration-sources.md
@@ -49,7 +49,7 @@ services:
     enabled: true|false
 ```
 
--  `services` can include `php`, `mysql`, `redis`, `elasticsearch`, `rabbitmq`, `cron`, and so on
+-  `services` can include `php`, `mysql`, `redis`, `elasticsearch`, `opensearch`, `rabbitmq`, `cron`, and so on
 -  `version` specifies a [supported service version][Service configuration options]. The version must be compatible with the Adobe Commerce version you deploy.
 -  `enabled` defaults to `true` if not set
 

--- a/src/pages/docker/setup/initialize-docker.md
+++ b/src/pages/docker/setup/initialize-docker.md
@@ -59,7 +59,7 @@ An on-premises installation requires the stand-alone `magento/magento-cloud-dock
        mode: 'production'
    services:
        php:
-           version: '7.3'
+           version: '8.1'
            extensions:
                enabled:
                    - xsl
@@ -71,9 +71,9 @@ An on-premises installation requires the stand-alone `magento/magento-cloud-dock
        redis:
            version: '5.0'
            image: 'redis'
-       elasticsearch:
-           version: '7.5'
-           image: 'magento/magento-cloud-docker-elasticsearch'
+       opensearch:
+           version: '1.2'
+           image: 'magento/magento-cloud-docker-opensearch'
    hooks:
        build: |
            set -e


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) ports changes from the [`2.4.6-develop`](https://github.com/magento-commerce/devdocs/tree/2.4.6-develop) branch in the magento-commerce/devdocs repo that were contributed prior to our migration to adobe.com sites.

I did a [compare](https://github.com/magento-commerce/devdocs/compare/master...2.4.6-develop) with `master` and then reviewed the migrated sources. Some of the changes were already ported over, but some were not.

COMDOX-328

## Affected pages

- See changed files