### PR TITLE
Clean up the Docker formatting and grammar

### DIFF
--- a/src/pages/docker/configure/custom-docker-compose.md
+++ b/src/pages/docker/configure/custom-docker-compose.md
@@ -5,13 +5,15 @@ description: Learn how to build a custom Docker Compose configuration for use wi
 
 # Build a custom Docker Compose configuration
 
-Instead of using the Adobe Commerce on cloud infrastructure project configuration to build the `docker-compose.yaml` file, you can use the `ece-docker build:custom:compose` command. Using this command with a JSON configuration is the quickest way to change your environment settings.
+Build a custom configuration using ECE-tools.
 
-You provide the configuration as a JSON array as shown in [Example 1](#example-1-custom-docker-composeyaml-file).
+Instead of using the Adobe Commerce on cloud infrastructure project configuration to build the `docker-compose.yaml` file, you can use the `ece-docker build:custom:compose` command. Using this command with a JSON configuration is the quickest way to change your environment settings. You provide the configuration as a JSON array as shown in [Example 1](#custom-docker-composeyaml-file).
 
-For Cloud Docker for Commerce 1.2 and later, you can specify custom images and image versions using the `ece-docker build:custom:compose` command as shown in [Example 2](#example-2-custom-docker-composeyaml-file-with-custom-images-and-image-versions).
+For Cloud Docker for Commerce 1.2 and later, you can specify custom images and image versions using the `ece-docker build:custom:compose` command as shown in [Example 2](#custom-docker-composeyaml-file-with-custom-images-and-image-versions).
 
-### Example 1: Custom `docker-compose.yaml` file
+## Examples
+
+### Custom `docker-compose.yaml` file
 
 ```bash
 ./vendor/bin/ece-docker build:custom:compose '{"name":"magento","system":{"mode":"production","host":"magento2.test","port":"8080","db":{"increment_increment":3,"increment_offset":2},"mailhog":{"smtp_port":"1026","http_port":"8026"}},"services":{"php":{"version":"7.3","enabled":true,"extensions":{"enabled":["xsl"]}},"mysql":{"version":"10.2","image":"mariadb","enabled":true}, "mailhog": {"enabled":true}}}'
@@ -164,7 +166,7 @@ networks:
     driver: bridge
 ```
 
-### Example 2: Custom `docker-compose.yaml` file with custom images and image versions
+### Custom `docker-compose.yaml` file with custom images and image versions
 
 ```bash
 ./vendor/bin/ece-docker build:custom:compose '{"name":"magento","system":{"mode":"production","host":"magento2.test","port":"8080","db":{"increment_increment":3,"increment_offset":2},"mailhog":{"smtp_port":"1026","http_port":"8026"}},"services":{"php":{"image":"php-v1","version":"7.4","enabled":true},"php-cli":{"image-pattern":"%s:%s-cli"},"php-fpm":{"image-pattern":"%s:%s-fpm"},"mysql":{"image":"mariadb-v1","version":"10.3","image-pattern":"%s:%s","enabled":true},"redis":{"image":"redis-v1","enabled":"true","version":"5"},"elasticsearch":{"image":"elasticsearch-v1","image-pattern":"%s:%s","enabled":true,"version":"7.6"},"varnish":{"image":"varnish-v1","image-pattern":"%s:%s","enabled":true,"version":"6.2"},"nginx":{"image":"nginx-v1","version":"1.19","image-pattern":"%s:%s","enabled":"true"},"test":{"enabled":true}},"mounts":{"var":{"path":"var"},"app-etc":{"path":"app\/etc"},"pub-media":{"path":"pub\/media"},"pub-static":{"path":"pub\/static"}}}'

--- a/src/pages/docker/configure/extend-docker-configuration.md
+++ b/src/pages/docker/configure/extend-docker-configuration.md
@@ -5,7 +5,7 @@ description: Learn how to extend your Cloud Docker for Commerce configuration us
 
 # Extend the Docker configuration
 
-You can use the built-in extension mechanism of Docker to specify [multiple compose files][].
+You can use the built-in Docker extension mechanism to specify [multiple compose files][].
 
 The following example replaces the default value of the `ENABLE_SENDMAIL` environment variable.
 

--- a/src/pages/docker/configure/extend-docker-configuration.md
+++ b/src/pages/docker/configure/extend-docker-configuration.md
@@ -5,7 +5,9 @@ description: Learn how to extend your Cloud Docker for Commerce configuration us
 
 # Extend the Docker configuration
 
-You can use the built-in extension mechanism of Docker to specify [multiple compose files][]. The following example replaces the default value of the `ENABLE_SENDMAIL` environment variable.
+You can use the built-in extension mechanism of Docker to specify [multiple compose files][].
+
+The following example replaces the default value of the `ENABLE_SENDMAIL` environment variable.
 
 1. Create a `docker-compose-dev.yml` file inside your project root directory and add the following content:
 
@@ -20,7 +22,7 @@ You can use the built-in extension mechanism of Docker to specify [multiple comp
 1. Pass both configuration files while executing your commands. For example:
 
    ```bash
-   docker-compose -f docker-compose.yml -f docker-compose-dev.yml run deploy bash
+   docker compose -f docker-compose.yml -f docker-compose-dev.yml run deploy bash
    ```
 
 ## Specify Docker build sources
@@ -40,7 +42,7 @@ services:
 Use the `--force-recreate` option to refresh the container build to update the container configuration and test iteratively:
 
 ```bash
-docker-compose up -d --force-recreate --build
+docker compose up -d --force-recreate --build
 ```
 
 ## Add a version of existing service
@@ -143,7 +145,7 @@ You can add PHP extensions to the PHP container by adding the extension configur
       ];
       ```
 
-   -  If you add the extension to the `.magento.app.yaml` for your Cloud project, you must regenerate the Docker compose configuration file and restart the Docker container.
+   -  If you add the extension to the `.magento.app.yaml` for your Cloud project, you must regenerate the Docker Compose configuration file and restart the Docker container.
 
 1. Add any required `.ini` files to the PHP FPM container configuration.
 
@@ -204,7 +206,7 @@ Use the following attributes to specify the PHP extension configuration in the `
 
 For information about extension types and extension installation, see the **How to install more PHP extensions** section of the [PHP, Docker Official Images][] page in _Docker Hub_.
 
-#### Example: Core extension configuration
+### Example: Core extension configuration
 
 The following example shows the configuration for adding the PHP core extension `gd` in the `ExtensionResolver.php` file.
 
@@ -249,7 +251,7 @@ public static function getConfig(): array
 ...
 ```
 
-#### Example: Configuration for extension installed using a script
+### Example: Configuration for extension installed using a script
 
 The following example shows the configuration for installing the `ioncube` extension using an installation script.
 

--- a/src/pages/docker/configure/index.md
+++ b/src/pages/docker/configure/index.md
@@ -5,7 +5,9 @@ description: Learn how to manage the Cloud Docker for Commerce environment with 
 
 # Configure the Docker environment
 
-Cloud Docker for Commerce uses Docker Compose to build and deploy Adobe Commerce to a multi-container Docker application. You can generate the Docker Compose configuration to build and deploy Docker from the following sources:
+Cloud Docker for Commerce uses Docker Compose to build and deploy Adobe Commerce to a multi-container Docker application.
+
+You can generate the Docker Compose configuration to build and deploy Docker from the following sources:
 
 - [Adobe Commerce on cloud infrastructure project configuration files](configuration-sources.md#cloud-configuration-for-commerce) for Cloud projects
 - [Unified configuration](configuration-sources.md#unified-configuration) for On-premises projects
@@ -42,23 +44,25 @@ When you build your Docker image with this variable, Cloud Docker uses this vers
 
 Sometimes you might want to run Docker on a different host and port, for example if you need more than one Docker instance.
 
-To configure the custom host and port, add the `host` and `port` options to the `build:compose` command.
+**To configure the custom host and port**:
 
-```bash
-./vendor/bin/ece-docker build:compose --host=magento2.test --port=8080
-```
+1. Add the `host` and `port` options to the `build:compose` command.
 
-You must add or update the custom host name in your `/etc/hosts` file.
+   ```bash
+   ./vendor/bin/ece-docker build:compose --host=magento2.test --port=8080
+   ```
 
-```conf
-127.0.0.1 magento2.test
-```
+1. Add or update the custom host name in your `/etc/hosts` file.
 
-Alternatively, you can run the following command to add it to the file:
+   ```conf
+   127.0.0.1 magento2.test
+   ```
 
-```bash
-echo "127.0.0.1 magento2.test" | sudo tee -a /etc/hosts
-```
+   Alternatively, you can run the following command to add it to the file:
+
+   ```bash
+   echo "127.0.0.1 magento2.test" | sudo tee -a /etc/hosts
+   ```
 
 ## Set up email
 

--- a/src/pages/docker/configure/manage-cron-jobs.md
+++ b/src/pages/docker/configure/manage-cron-jobs.md
@@ -25,11 +25,11 @@ To improve the overall performance in the Docker development and production envi
 **To view the cron log:**
 
 ```bash
-docker-compose run --rm deploy bash -c "cat /app/var/cron.log"
+docker compose run --rm deploy bash -c "cat /app/var/cron.log"
 ```
 
 **To run cron jobs manually:**
 
 ```bash
-docker-compose run --rm cron /usr/local/bin/php bin/magento cron:run
+docker compose run --rm cron /usr/local/bin/php bin/magento cron:run
 ```

--- a/src/pages/docker/configure/manage-database.md
+++ b/src/pages/docker/configure/manage-database.md
@@ -13,7 +13,7 @@ You connect to the database using `docker compose` commands. You can also import
 
 You can connect to the database through the Docker container or through the database port. Before you begin, locate the database credentials in the `database` section of the `.docker/config.php` file.
 
-The examples use the following default credentials:
+The procedures in this topic use the following default credentials:
 
 ```php?start_inline=1
 return [

--- a/src/pages/docker/configure/manage-database.md
+++ b/src/pages/docker/configure/manage-database.md
@@ -7,7 +7,7 @@ description: Learn how to access and manage the database in the Cloud Docker for
 
 The Cloud Docker development environment provides MySQL services through a MariaDB (default) or MySQL database deployed to the [Docker database container](../containers/service.md#database-container).
 
-You connect to the database using `docker-compose` commands. You can also import data from an existing Adobe Commerce on cloud infrastructure project into the database container using the `magento-cloud db:dump` command.
+You connect to the database using `docker compose` commands. You can also import data from an existing Adobe Commerce on cloud infrastructure project into the database container using the `magento-cloud db:dump` command.
 
 ## Connect to the database
 

--- a/src/pages/docker/configure/manage-database.md
+++ b/src/pages/docker/configure/manage-database.md
@@ -5,13 +5,15 @@ description: Learn how to access and manage the database in the Cloud Docker for
 
 # Manage the database
 
-The Cloud Docker development environment provides MySQL services through a MariaDB (default) or MySQL database deployed to the [Docker database container](../containers/service.md#database-container). You connect to the database using `docker-compose` commands. You can also import data from an existing Adobe Commerce on cloud infrastructure project into the database container using the `magento-cloud db:dump` command.
+The Cloud Docker development environment provides MySQL services through a MariaDB (default) or MySQL database deployed to the [Docker database container](../containers/service.md#database-container).
+
+You connect to the database using `docker-compose` commands. You can also import data from an existing Adobe Commerce on cloud infrastructure project into the database container using the `magento-cloud db:dump` command.
 
 ## Connect to the database
 
-You can connect to the database through the Docker container or through the database port. Before you begin, locate the database credentials in the `database` section of the `.docker/config.php` file. The examples use the following default credentials:
+You can connect to the database through the Docker container or through the database port. Before you begin, locate the database credentials in the `database` section of the `.docker/config.php` file.
 
-Filename: `.docker/config.php`
+The examples use the following default credentials:
 
 ```php?start_inline=1
 return [
@@ -51,7 +53,7 @@ return [
 1. Connect to the CLI container.
 
    ```bash
-   docker-compose run --rm deploy bash
+   docker compose run --rm deploy bash
    ```
 
 1. Connect to the database with a username and password.
@@ -86,7 +88,7 @@ return [
 1. Find the port used by the database. The port can change each time you restart Docker.
 
    ```bash
-   docker-compose ps
+   docker compose ps
    ```
 
    Sample response:
@@ -154,7 +156,7 @@ Before you import a database from an existing Adobe Commerce installation into a
 
 1. Place the resulting SQL file into the `.docker/mysql/docker-entrypoint-initdb.d` folder.
 
-   The `ece-tools` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker-compose up` command. When you build, you must add the `--with-entrypoint` option to the `ece-docker build:compose` command. This option configures the directories for the imported database. See [Service configuration options](../containers/index.md#service-configuration-options).
+   The `ece-tools` package imports and processes the SQL file the next time you build and start the Docker environment using the `docker compose up` command. When you build, you must add the `--with-entrypoint` option to the `ece-docker build:compose` command. This option configures the directories for the imported database. See [Service configuration options](../containers/index.md#service-configuration-options).
 
 <InlineAlert variant="help" slots="text"/>
 

--- a/src/pages/docker/configure/multiple-sites.md
+++ b/src/pages/docker/configure/multiple-sites.md
@@ -5,7 +5,9 @@ description:
 
 # Configure multiple websites or stores
 
-Cloud Docker supports multiple websites or stores by adding subdomains to your configuration. See [Understanding websites, stores, and store views][].
+Cloud Docker supports multiple websites or stores by adding subdomains to your configuration.
+
+See [Understanding websites, stores, and store views][].
 
 **To add support for multiple websites and stores**:
 

--- a/src/pages/docker/containers/cli.md
+++ b/src/pages/docker/containers/cli.md
@@ -5,7 +5,9 @@ description: Learn about the Cloud Docker for Commerce CLI containers, images us
 
 # CLI containers
 
-The following CLI containers, most of which are based on a [PHP-CLI version 7 image][], provide `magento-cloud` and `ece-tools` commands to perform file system operations and interact with the application:
+The following CLI containers, most of which are based on a [PHP-CLI version 7 image][], provide `magento-cloud` and `ece-tools` commands to perform file system operations and interact with the application.
+
+Operations include:
 
 - `build`—extends the CLI container to perform operations with writable filesystem, similar to the build phase
 - `deploy`—extends the CLI container to use read-only file system, similar to the deploy phase
@@ -14,10 +16,8 @@ The following CLI containers, most of which are based on a [PHP-CLI version 7 im
 
 For example, you can check the state of your project using the _ideal-state_ wizard:
 
-Run the `ece-tools` ideal-state command.
-
 ```bash
-docker-compose run --rm deploy ece-command wizard:ideal-state
+docker compose run --rm deploy ece-command wizard:ideal-state
 ```
 
 Sample response:
@@ -52,10 +52,10 @@ See the [scripts in the Cloud Docker for Commerce GitHub repository][scripts] to
 
 The Build container mimics the behavior of the Adobe Commerce on cloud infrastructure build process so that testing the build and deploy process is as close to testing in production as possible.
 
-You can also run build commands manually from the build container to perform individual steps from the build process. For example, you can run the following command to deploy static content.
+You can run build commands manually from the build container to perform individual steps from the build process. For example, you can run the following command to deploy static content:
 
 ```bash
-docker-compose run --rm build magento-command setup:static-content:deploy
+docker compose run --rm build magento-command setup:static-content:deploy
 ```
 
 ## Cron container
@@ -81,7 +81,7 @@ The Deploy container mimics the Adobe Commerce on cloud infrastructure deploy pr
 You can run `build` and `deploy` commands manually from the deploy container. The following example reindexes the Adobe Commerce store:
 
 ```bash
-docker-compose run --rm deploy magento-command index:reindex
+docker compose run --rm deploy magento-command index:reindex
 ```
 
 ## Node container

--- a/src/pages/docker/containers/index.md
+++ b/src/pages/docker/containers/index.md
@@ -5,9 +5,9 @@ description: Learn about the container architecture for Cloud Docker for Commerc
 
 # Container Architecture
 
-The [`magento-cloud-docker` repository][docker-repo] contains build information to create a Docker environment with the required specifications for Adobe Commerce on cloud infrastructure. The build configuration creates a Docker instance with CLI and service containers required to run Adobe Commerce on cloud infrastructure in a local Docker environment. You can customize the Docker containers available in the repository and add more as needed.
+The `magento-cloud-docker` package contains build information to create a Docker environment with the required specifications for Adobe Commerce.
 
-Cloud Docker for Commerce generates the `docker-compose.yml` file to the required specifications. Then, you use docker-compose to create the container instances and to build and deploy the Adobe Commerce site.
+The build configuration creates a Docker instance with CLI and service containers required to preview and test an Adobe Commerce project in a local Docker environment. Cloud Docker for Commerce generates the `docker-compose.yml` file to the required specifications. Then, you use docker-compose to create the container instances and to build and deploy the Adobe Commerce site.
 
 ## CLI Containers
 
@@ -20,14 +20,16 @@ The following CLI containers, most of which are based on a PHP-CLI version 7 Doc
 | [build](cli.md#build-container) | Build Container  | none | none | PHP Container, runs build process |
 | [deploy](cli.md#deploy-container) | Deploy Container | none | none | PHP Container, runs the deploy process |
 
+See [CLI containers](cli.md).
+
 ## Service containers
 
 Cloud Docker for Commerce references the `.magento.app.yaml` and `.magento/services.yaml` configuration files to determine the services you need. When you start the Docker configuration generator using the `ece-docker build:compose` command, use the optional build parameters to override a default service version or specify custom configuration.
 
-For example, the following command starts the Docker configuration generator in developer mode and specifies PHP version 7.2:
+For example, the following command starts the Docker configuration generator in developer mode and specifies PHP version 8.1:
 
 ```bash
-./vendor/bin/ece-docker build:compose --mode="developer" --php 7.2
+./vendor/bin/ece-docker build:compose --mode="developer" --php 8.1
 ```
 
 See [Service containers](service.md).
@@ -40,7 +42,7 @@ The following table shows the options to customize service container configurati
 |------------------|----------------------|-------------------------|-----------------------------------------------|------------------------------|
 | [db](service.md#database-container) | MariaDB or MySQL | `--db`, `--db-image` (MySQL)<br/>`--expose-db-port`<br/>`--db-increment`<br/>`--db-offset`<br/>`--with-entrypoint`<br/>`--with-mariadb-config` | 10.0, 10.1, 10.2, 10.3, 10.4<br/>5.6, 5.7, 8.0 | Use the increment and offset options to customize the [auto-increment settings][Using AUTO_INCREMENT] for replication.<br/><br/>Use the `--with-entrypoint` and `--with-mariadb-config` options to automatically configure database directories in the Docker environment<br/><br/>**Example build commands**:<br/>`ece-docker build:compose --db <mariadb-version>`<br/>`ece-docker build:compose --db <mysql-version> --db-image` |
 | [elasticsearch](service.md#elasticsearch-container) | Elasticsearch | `--es`<br/>`--es-env-var`<br/>`--no-es` | 5.2, 6.5, 6.8, 7.5, 7.6, 7.7, 7.9, 7.10, 7.11 | Use the options to specify the Elasticsearch version,  customize Elasticsearch configuration options, or to build a Docker environment without Elasticsearch. |
-| [opensearch](service.md#opensearch-container) | OpenSearch | `--os`<br/>`--os-env-var`<br/>`--no-os` | 1.1, 1.2 | Use the options to specify the Openseach version, customize OpenSearch configuration options, or to build a Docker environment without OpenSearch.|
+| [opensearch](service.md#opensearch-container) | OpenSearch | `--os`<br/>`--os-env-var`<br/>`--no-os` | 1.1, 1.2 | Use the options to specify the OpenSearch version, customize OpenSearch configuration options, or to build a Docker environment without OpenSearch.|
 | [fpm](service.md#fpm-container) | PHP FPM | `--php`<br/>`--with-xdebug` | 7.2, 7.3, 7.4, 8.0 | Used for all incoming requests. Optionally, install a specific php version or add Xdebug to debug PHP code in the Docker environment. |
 | [mailhog](service.md#mailhog-container) | MailHog | `--no-mailhog`<br/>`--mailhog-http-port`<br/>`--mailhog-smtp-port` | latest | Email service to replace Sendmail service, which can cause issues in Docker environment |
 | [node](cli.md#node-container) | Node | `--node` | 6, 8, 10, 11 | Node container to run gulp or other NPM based commands in the Docker environment. Use the `--node` option to install a specific node version. |
@@ -73,7 +75,7 @@ You can remove Varnish from the configuration, in which case the traffic passes 
 
 ## Sharing data between host machine and container
 
-You can share files easily between your machine and a Docker container by placing the files in the `.docker/mnt` directory. You can find the files in the `/mnt` directory the next time you build and start the Docker environment using the `docker-compose up` command.
+You can share files easily between your machine and a Docker container by placing the files in the `.docker/mnt` directory. You can find the files in the `/mnt` directory the next time you build and start the Docker environment using the `docker compose up` command.
 
 ## Sharing project data
 
@@ -101,21 +103,21 @@ You can customize this configuration by updating the [`mounts`][mount-configurat
 
 ### File synchronization
 
-Additionally, you can share data into the containers using file synchronization. See the [File synchronization](../setup/synchronize-data.md) and [Developer mode](../deploy/developer-mode.md) documentation.
+Also, you can share data into the containers using file synchronization. See the [File synchronization](../setup/synchronize-data.md) and [Developer mode](../deploy/developer-mode.md) documentation.
 
 ## Container Volumes
 
 Cloud Docker for Commerce uses Docker volumes to maintain data throughout the lifecycle of the Docker containers. These volumes can be defined in several ways:
 
-- in a `docker-compose.yml` or other docker-compose files
-- in the Dockerfile from the [magento-cloud-docker repository](https://github.com/magento/magento-cloud-docker)
-- in the upstream Docker image
+- Docker Compose files such as `docker-compose.yml`
+- Dockerfile from the [magento-cloud-docker repository](https://github.com/magento/magento-cloud-docker)
+- Upstream Docker image
 
 You do not interact with most of these volumes, which are used by the Docker containers and follow the docker-compose lifecycle. The only exception to this is the `magento-sync` directory that is an external volume used by the Mutagen application to transport data into the containers from the host operating system.
 
 ### Rebuild a clean environment
 
-The `docker-compose down` command removes all components of your local Docker instance, including containers, networks, volumes, and images. However, this command does not affect [the persistent database volume](service.md#database-container) or the `magento-sync` volume used for file synchronization.
+The `docker compose down` command removes all components of your local Docker instance, including containers, networks, volumes, and images. However, this command does not affect [the persistent database volume](service.md#database-container) or the `magento-sync` volume used for file synchronization.
 
 **To remove all data and rebuild a clean environment**:
 
@@ -134,7 +136,7 @@ ERROR: Volume magento-sync declared as external, but could not be found. Please 
 All containers use the Docker logging method. You can view the logs using the `docker-compose` command. The following example uses the `-f` option to _follow_ the log output of the TLS container:
 
 ```bash
-docker-compose logs -f tls
+docker compose logs -f tls
 ```
 
 Now you can see all requests that are passing through the TLS container and check for errors.

--- a/src/pages/docker/containers/index.md
+++ b/src/pages/docker/containers/index.md
@@ -7,7 +7,7 @@ description: Learn about the container architecture for Cloud Docker for Commerc
 
 The `magento-cloud-docker` package contains build information to create a Docker environment with the required specifications for Adobe Commerce.
 
-The build configuration creates a Docker instance with CLI and service containers required to preview and test an Adobe Commerce project in a local Docker environment. Cloud Docker for Commerce generates the `docker-compose.yml` file to the required specifications. Then, you use docker-compose to create the container instances and to build and deploy the Adobe Commerce site.
+The build configuration creates a Docker instance with CLI and service containers required to preview and test an Adobe Commerce project in a local Docker environment. Cloud Docker for Commerce generates the `docker-compose.yml` file to the required specifications. Then, use `docker compose` to create the container instances and build and deploy the Adobe Commerce site.
 
 ## CLI Containers
 

--- a/src/pages/docker/containers/service.md
+++ b/src/pages/docker/containers/service.md
@@ -9,7 +9,7 @@ The following containers provide the services required to build, deploy, and run
 
 <InlineAlert variant="info" slots="text"/>
 
-See [Service configuration options](index.md#service-containers) to customize container configuration when you build the Docker compose configuration file.
+See [Service configuration options](index.md#service-containers) to customize container configuration when you build the Docker Compose configuration file.
 
 ## Database container
 
@@ -24,9 +24,9 @@ You can configure the database container to use either MariaDB or MySQL for the 
 
 To use MySQL for the database, add the `--db image` option when you generate the Docker Compose configuration file. See [Service configuration options](index.md#service-containers).
 
-When a database container initializes, it creates a database with the specified name and uses the configuration variables specified in the docker-compose configuration. The initial start-up process also executes files with `.sh`, `.sql`, and `.sql.gz` extensions that are found in the `/docker-entrypoint-initdb.d` directory. Files are executed in alphabetical order. See [mariadb Docker documentation][].
+When a database container initializes, it creates a database with the specified name and uses the configuration variables specified in the Docker Compose configuration. The initial start-up process also executes files with `.sh`, `.sql`, and `.sql.gz` extensions that are found in the `/docker-entrypoint-initdb.d` directory. Files are executed in alphabetical order. See [mariadb Docker documentation][].
 
-To prevent accidental data loss, the database is stored in a persistent `magento-db` volume after you stop and remove the Docker configuration. The next time you use the `docker-compose up` command, the Docker environment restores your database from the persistent volume. You must manually destroy the database volume using the `docker volume rm <volume_name>` command.
+To prevent accidental data loss, the database is stored in a persistent `magento-db` volume after you stop and remove the Docker configuration. The next time you use the `docker compose up` command, the Docker environment restores your database from the persistent volume. You must manually destroy the database volume using the `docker volume rm <volume_name>` command.
 
 You can inject a MySQL configuration into the database container at creation by adding the configuration to the `docker-compose-override.yml` file using any of the following methods:
 
@@ -109,7 +109,7 @@ sysctl -w vm.max_map_count=262144
 
 1. Reboot your system.
 
-1. Run the following command to verify the change.
+1. Verify the change.
 
    ```bash
    sysctl vm.max_map_count
@@ -213,7 +213,7 @@ Optionally, you can add Xdebug to your Cloud Docker environment to debug your PH
 
 The default Cloud Docker configuration includes the [MailHog service][] as a replacement for the Sendmail service. Sendmail can cause performance issues in the local Docker environment.
 
-By default, MailHog listens on port 1025 for SMTP and port 8025 for the frontend dashboard and API (HTTP). You can change the default ports using the `--mailhog-http-port` and `--mailhog-smtp-port` options. When you build the Docker compose configuration, you can change the default ports:
+By default, MailHog listens on port 1025 for SMTP and port 8025 for the frontend dashboard and API (HTTP). You can change the default ports using the `--mailhog-http-port` and `--mailhog-smtp-port` options. When you build the Docker Compose configuration, you can change the default ports:
 
 ```bash
 ./vendor/bin/ece-docker build:compose --mailhog-smtp-port=1025 --mailhog-http-port=8025
@@ -221,7 +221,7 @@ By default, MailHog listens on port 1025 for SMTP and port 8025 for the frontend
 
 After updating the configuration and restarting the Docker environment, you can connect to the MailHog service from `http://magento2.docker:8025`, and use port 1025 for SMTP communication.
 
-If needed, you can disable the MailHog service when you generate the Docker compose configuration:
+If needed, you can disable the MailHog service when you generate the Docker Compose configuration:
 
 ```bash
 ./vendor/bin/ece-docker build:compose --no-mailhog
@@ -246,7 +246,7 @@ The Redis container for Cloud Docker for Commerce is a standard container with n
 Connect to and run Redis commands using the `redis-cli` property inside the container:
 
 ```bash
-docker-compose run --rm redis redis-cli -h redis
+docker compose run --rm redis redis-cli -h redis
 ```
 
 ## Selenium container
@@ -311,7 +311,7 @@ You can specify `VARNISHD_PARAMS` and other environment variables using ENV to s
 **To clear the Varnish cache**:
 
 ```bash
-docker-compose exec varnish varnishadm ban req.url '~' '.'
+docker compose exec varnish varnishadm ban req.url '~' '.'
 ```
 
 ## Web container

--- a/src/pages/docker/deploy/developer-mode.md
+++ b/src/pages/docker/deploy/developer-mode.md
@@ -5,9 +5,9 @@ description: Start the Docker environment in developer mode.
 
 # Developer mode
 
-Developer mode supports an active development environment with full, writable file system permissions. This option builds the Docker environment in developer mode and verifies configured service versions.
+Developer mode supports an active development environment with full, writable file system permissions.
 
-On macOS and Windows systems, performance is slower in developer mode because of additional file synchronization operations. However, you can improve performance by using either the `manual-native` or the `mutagen` file synchronization option when you generate the `docker-compose.yml` file. See [Synchronizing data in Docker](../setup/synchronize-data.md).
+This option builds the Docker environment in developer mode and verifies configured service versions. On macOS and Windows systems, performance is slower in developer mode because of additional file synchronization operations. However, you can improve performance by using either the `manual-native` or the `mutagen` file synchronization option when you generate the `docker-compose.yml` file. See [Synchronizing data in Docker](../setup/synchronize-data.md).
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -32,7 +32,7 @@ Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files
 
    The `--mode` option in this step determines the mode in a later `deploy` step.
 
-   If required, set the option for [synchronizing data in Docker][sync]. For example:
+   If necessary, set the option for [synchronizing data in Docker][sync]. For example:
 
    ```bash
    ./vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen"
@@ -51,7 +51,7 @@ Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files
 1. Build files to containers and run in the background.
 
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 1. If you selected the `manual-native` option, start the file synchronization.
@@ -62,7 +62,7 @@ Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files
    ./bin/magento-docker copy-to --all
    ```
 
-   Additionally, you can provide a specific directory from the local machine to copy to the Docker volume, for example `vendor`:
+   Also, you can provide a specific directory from the local machine to copy to the Docker volume, for example `vendor`:
 
    ```bash
    ./bin/magento-docker copy-to vendor
@@ -74,7 +74,7 @@ Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files
    ./bin/magento-docker copy-from --all
    ```
 
-   Additionally, you can provide a specific directory from the Docker volume to copy from, such as `vendor`:
+   Also, you can provide a specific directory from the Docker volume to copy from, such as `vendor`:
 
    ```bash
    ./bin/magento-docker copy-from vendor
@@ -86,28 +86,28 @@ Large files (>1 GB) can cause a period of inactivity. DB dumps and archive files
    bash ./mutagen.sh
    ```
 
-<InlineAlert variant="help" slots="text"/>
+   **Important**:
 
-If you host your Docker environment on Windows and the session start fails, update the `mutagen.sh` file to change the value for the `--symlink-mode` option to `portable`.
+   If you host your Docker environment on Windows and the session start fails, update the `mutagen.sh` file to change the value for the `--symlink-mode` option to `portable`.
 
 1. Install Adobe Commerce in your Docker environment.
 
-   -  For Adobe Commerce version 2.4 and 2.4.1 only, run the following command to apply patches before you deploy.
+   -  For Adobe Commerce version 2.4 and 2.4.1 only, apply patches before you deploy.
 
       ```bash
-      docker-compose run --rm deploy php ./vendor/bin/ece-patches apply
+      docker compose run --rm deploy php ./vendor/bin/ece-patches apply
       ```
 
    -  Deploy Adobe Commerce in the Docker container.
 
       ```bash
-      docker-compose run --rm deploy cloud-deploy
+      docker compose run --rm deploy cloud-deploy
       ```
 
    -  Run post-deploy hooks.
 
        ```bash
-       docker-compose run --rm deploy cloud-post-deploy
+       docker compose run --rm deploy cloud-post-deploy
        ```
 
    <!-- <InlineAlert variant="info" slots="text"/> -->
@@ -117,17 +117,17 @@ If you host your Docker environment on Windows and the session start fails, upda
 1. Configure and connect Varnish.
 
    ```bash
-   docker-compose run --rm deploy magento-command config:set system/full_page_cache/caching_application 2 --lock-env
+   docker compose run --rm deploy magento-command config:set system/full_page_cache/caching_application 2 --lock-env
    ```
 
    ```bash
-   docker-compose run --rm deploy magento-command setup:config:set --http-cache-hosts=varnish
+   docker compose run --rm deploy magento-command setup:config:set --http-cache-hosts=varnish
    ```
 
 1. Clear the cache.
 
    ```bash
-   docker-compose run --rm deploy magento-command cache:clean
+   docker compose run --rm deploy magento-command cache:clean
    ```
 
 1. Access the local storefront by opening one of the following URLs in a browser:

--- a/src/pages/docker/deploy/index.md
+++ b/src/pages/docker/deploy/index.md
@@ -41,15 +41,15 @@ You can stop containers and restore them afterwards using the following methods.
 
 | Action | Command |
 | ------ | ------- |
-| Suspend containers to continue your work later | `docker-compose stop` |
-| Stop and remove all containers, images, and volumes | `docker-compose down` |
-| Start containers from a suspended state | `docker-compose start` |
+| Suspend containers to continue your work later | `docker compose stop` |
+| Stop and remove all containers, images, and volumes | `docker compose down` |
+| Start containers from a suspended state | `docker compose start` |
 
 Use the following command to stop and remove the Docker configuration:
 
-   ```bash
-   docker-compose down -v
-   ```
+```bash
+docker compose down -v
+```
 
 <InlineAlert variant="warning" slots="text"/>
 

--- a/src/pages/docker/deploy/index.md
+++ b/src/pages/docker/deploy/index.md
@@ -7,9 +7,7 @@ description: Deploy your Commerce application in a Docker environment designed f
 
 By default, Cloud Docker for Commerce deploys Adobe Commerce to a read-only file system in the Docker environment.
 
-This deployment mirrors the read-only file system in the Production environment. You can deploy a Docker environment in developer mode, which provides an active development environment with full, writable file system permissions.
-
-You use the `ece-docker build:compose` command to generate the Docker Compose configuration file from specified configuration settings and to deploy Adobe Commerce on cloud infrastructure to a local Docker environment. You supply the configuration settings from multiple sources depending on your requirements. See [Configure sources](../configure/configuration-sources.md).
+The default deployment mirrors the read-only file system in the cloud infrastructure Production environment. You can deploy a Docker environment in developer mode, which provides an active development environment with full, writable file system permissions. The `ece-docker build:compose` command generates the Docker Compose configuration file from project configuration settings and to deploy Adobe Commerce on cloud infrastructure to a local Docker environment. You supply the configuration settings from multiple sources depending on your requirements. See [Configure sources](../configure/configuration-sources.md).
 
 <InlineAlert variant="warning" slots="text"/>
 

--- a/src/pages/docker/deploy/production-mode.md
+++ b/src/pages/docker/deploy/production-mode.md
@@ -5,7 +5,9 @@ description: Start the Docker environment in production mode.
 
 # Production mode
 
-Production mode simulates your Commerce application in production so that you can verify configured services. Production mode is the default configuration setting for launching the Docker environment with read-only filesystem permissions.
+Production mode simulates your Commerce application in production so that you can verify configured services.
+
+Production mode is the default configuration setting for launching the Docker environment with read-only filesystem permissions.
 
 **Prerequisites:**
 
@@ -28,7 +30,7 @@ Complete the [installation steps](../setup/initialize-docker.md).
 1. Build files to containers and run in the background.
 
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 1. Install Adobe Commerce in your Docker environment.
@@ -36,41 +38,41 @@ Complete the [installation steps](../setup/initialize-docker.md).
    -  Build Adobe Commerce in the Docker container.
 
       ```bash
-      docker-compose run --rm build cloud-build
+      docker compose run --rm build cloud-build
       ```
 
    -  Deploy Adobe Commerce in the Docker container.
 
       ```bash
-      docker-compose run --rm deploy cloud-deploy
+      docker compose run --rm deploy cloud-deploy
       ```
 
    -  Run post-deploy hooks.
 
       ```bash
-      docker-compose run --rm deploy cloud-post-deploy
+      docker compose run --rm deploy cloud-post-deploy
       ```
 
 1. Configure and connect Varnish.
 
    ```bash
-   docker-compose run --rm deploy magento-command config:set system/full_page_cache/caching_application 2 --lock-env
+   docker compose run --rm deploy magento-command config:set system/full_page_cache/caching_application 2 --lock-env
    ```
 
    ```bash
-   docker-compose run --rm deploy magento-command setup:config:set --http-cache-hosts=varnish
+   docker compose run --rm deploy magento-command setup:config:set --http-cache-hosts=varnish
    ```
 
 1. Clear the cache.
 
    ```bash
-   docker-compose run --rm deploy magento-command cache:clean
+   docker compose run --rm deploy magento-command cache:clean
    ```
 
 1. _Optional_: Restart services if the static content does not synchronize with all images after generation on build phase.
 
    ```bash
-   docker-compose restart
+   docker compose restart
    ```
 
 1. Access the local storefront by opening one of the following URLs in a browser:

--- a/src/pages/docker/get-support.md
+++ b/src/pages/docker/get-support.md
@@ -36,7 +36,7 @@ sysctl -w vm.max_map_count=262144
 
 1. Reboot your system.
 
-1. Run the following command to verify the change.
+1. Verify the change.
 
    ```bash
    sysctl vm.max_map_count

--- a/src/pages/docker/quick-reference.md
+++ b/src/pages/docker/quick-reference.md
@@ -9,6 +9,8 @@ A quick reference of common commands for Docker Compose and Cloud Docker for Com
 
 ## Docker Compose
 
+Cloud Docker for Commerce uses the Docker Compose tool. The commands reflected in this guide are based on the latest usage defined in the [docker compose CLI reference](https://docs.docker.com/compose/reference/).
+
 The following table lists the `docker compose` commands for building, deploying, and operating Cloud Docker for Commerce.
 
 | Action                                                | Command                                                    |

--- a/src/pages/docker/quick-reference.md
+++ b/src/pages/docker/quick-reference.md
@@ -9,26 +9,26 @@ A quick reference of common commands for Docker Compose and Cloud Docker for Com
 
 ## Docker Compose
 
-The following table lists the `docker-compose` commands for building, deploying, and operating Cloud Docker for Commerce.
+The following table lists the `docker compose` commands for building, deploying, and operating Cloud Docker for Commerce.
 
 | Action                                                | Command                                                    |
 | :---------------------------------------------------- | :--------------------------------------------------------- |
-| Build and start Docker environment                    | `docker-compose up -d`                                     |
-| Build environment                                     | `docker-compose run --rm build cloud-build`                |
-| Deploy environment                                    | `docker-compose run --rm deploy cloud-deploy`              |
-| Run post-deploy hooks                                 | `docker-compose run --rm deploy cloud-post-deploy`         |
-| Connect to CLI container                              | `docker-compose run --rm deploy bash`                      |
-| Use `ece-tools` command                               | `docker-compose run --rm deploy ece-command <command>`     |
-| Use Magento command                                   | `docker-compose run --rm deploy magento-command <command>` |
-| Stop and remove Docker environment (removes volumes)  | `docker-compose down -v`                                   |
-| Stop Docker environment without destroying containers | `docker-compose stop`                                      |
-| Resume Docker environment                             | `docker-compose start`                                     |
-| List images                                           | `docker-compose images`                                    |
-| List containers and ports                             | `docker-compose ps` or `docker ps`                         |
+| Build and start Docker environment                    | `docker compose up -d`                                     |
+| Build environment                                     | `docker compose run --rm build cloud-build`                |
+| Deploy environment                                    | `docker compose run --rm deploy cloud-deploy`              |
+| Run post-deploy hooks                                 | `docker compose run --rm deploy cloud-post-deploy`         |
+| Connect to CLI container                              | `docker compose run --rm deploy bash`                      |
+| Use `ece-tools` command                               | `docker compose run --rm deploy ece-command <command>`     |
+| Use Magento command                                   | `docker compose run --rm deploy magento-command <command>` |
+| Stop and remove Docker environment (removes volumes)  | `docker compose down -v`                                   |
+| Stop Docker environment without destroying containers | `docker compose stop`                                      |
+| Resume Docker environment                             | `docker compose start`                                     |
+| List images                                           | `docker compose images`                                    |
+| List containers and ports                             | `docker compose ps` or `docker ps`                         |
 
 <InlineAlert variant="info" slots="text"/>
 
-The `--rm` option automatically removes containers when they stop. This setting overrides any restart policy specified in the service configuration and prevents orphaned containers from consuming excess disk space. See [`docker-compose run`](https://docs.docker.com/compose/reference/run/) in the _Docker command-line reference_.
+The `--rm` option automatically removes containers when they stop. This setting overrides any restart policy specified in the service configuration and prevents orphaned containers from consuming excess disk space. See [`docker composer run`](https://docs.docker.com/engine/reference/commandline/compose_run/) in the _Docker command-line reference_.
 
 ## Configuration generator
 
@@ -46,19 +46,19 @@ See [Service versions](../docker/containers/index.md) for additional information
 
 ### Override configuration
 
-Because the `ece-docker build:compose` command overwrites the base configuration, we recommend saving your customizations in an override configuration file. You can use this method to merge multiple custom configurations. See [Docker Docs: Multiple Compose files](https://docs.docker.com/compose/extends/#multiple-compose-files).
+Because the `ece-docker build:compose` command overwrites the base configuration, Adobe recommends saving your customizations in an override configuration file. You can use this method to merge multiple custom configurations. See [Docker Docs: Multiple Compose files](https://docs.docker.com/compose/extends/#multiple-compose-files).
 
-The `docker-compose up` command considers the base `docker-compose.yml` configuration by default. If the `docker-compose.override.yml` file is present, then the override configuration merges with the base configuration.
+The `docker compose up` command considers the base `docker compose.yml` configuration by default. If the `docker compose.override.yml` file is present, then the override configuration merges with the base configuration.
 
 Use the `-f` argument to specify an alternate configuration file. The following example uses the default configuration and merges each custom configuration sequentially:
 
 ```bash
-docker-compose -f docker-compose.yml -f docker-compose-custom.yml [-f more-custom-docker-compose.yml] up
+docker compose -f docker compose.yml -f docker compose-custom.yml [-f more-custom-docker compose.yml] up
 ```
 
 ## Cloud Docker CLI
 
-Use the Cloud Docker for Commerce `bin/magento-docker` CLI commands to run `docker-compose` tasks more efficiently. For example, instead of using a separate `docker-compose` command for the build, deploy, and post-deploy tasks in the Docker environment, you can use the `ece-redeploy` command to complete all tasks.
+Use the Cloud Docker for Commerce `bin/magento-docker` CLI commands to run `docker compose` tasks more efficiently. For example, instead of using a separate `docker compose` command for the build, deploy, and post-deploy tasks in the Docker environment, you can use the `ece-redeploy` command to complete all tasks.
 
 ```bash
 ./bin/magento-docker ece-redeploy
@@ -77,7 +77,7 @@ Use the following to connect to the bash shell and begin using the Cloud Docker 
 | Build application                                                                                              | `./bin/magento-docker ece-build`       |
 | Deploy application                                                                                             | `./bin/magento-docker ece-deploy`      |
 | Run post-deploy hooks                                                                                          | `./bin/magento-docker ece-post-deploy` |
-| Re-build and redeploy application                                                                             | `./bin/magento-docker ece-redeploy`    |
+| Re-build and redeploy application                                                                              | `./bin/magento-docker ece-redeploy`    |
 | Stop containers                                                                                                | `./bin/magento-docker stop`            |
 | Start containers                                                                                               | `./bin/magento-docker start`           |
 | Restart containers                                                                                             | `./bin/magento-docker restart`         |

--- a/src/pages/docker/setup/index.md
+++ b/src/pages/docker/setup/index.md
@@ -42,7 +42,7 @@ Before setting up a local workspace, gather the following credentials and accoun
 
 ## PHP and Composer
 
-Cloud Docker for Commerce does not require PHP and Composer to be installed locally. We provide an installation script to perform PHP and Composer operations.
+Cloud Docker for Commerce does not require PHP and Composer to be installed locally. Adobe provides an installation script to perform PHP and Composer operations.
 
 The `init-docker.sh` script runs the following command, which installs the template dependencies and sets both the PHP version and the Cloud Docker for Commerce image version.
 
@@ -56,7 +56,7 @@ The following table lists the available options to use with the `init-docker.sh`
 
 | Option          | Description |
 | :-------------- | :---------- |
-| `-p`, `--php`   | PHP version (for installing dependencies). You must specify a PHP version that is compatible with the Adobe Commerce version deployed to the Cloud Docker environment. |
+| `-p`, `--php`   | PHP version (for installing dependencies). Specify a PHP version that is compatible with the Adobe Commerce version deployed to the Cloud Docker environment. |
 | `-i`, `--image` |  Cloud Docker for Commerce image version (for installing dependencies).<br/>**Default**: `1.1` |
 | `--host`        | Domain name to add to the `/etc/hosts` file.<br/>**Default**: `magento2.docker` |
 | `--add-host`    | Add domain name to `/etc/hosts` file.<br/>**Default**: true (`yes`) |

--- a/src/pages/docker/setup/initialize-docker.md
+++ b/src/pages/docker/setup/initialize-docker.md
@@ -5,7 +5,7 @@ description: Learn how to begin preparing your Adobe Commerce project to use wit
 
 # Initialize Cloud Docker
 
-Cloud Docker for Commerce is one of the packages in the Cloud Suite for Commerce designed to deploy and manage local Adobe Commerce Docker environments for both cloud and on-premises projects.
+Cloud Docker for Commerce is one of the packages in the Cloud Suite for Commerce designed to deploy and manage local Adobe Commerce projects into Docker environments.
 
 <InlineAlert variant="success" slots="text"/>
 
@@ -17,7 +17,7 @@ Adobe Commerce on cloud infrastructure tooling contains the `magento/magento-clo
 
 **To install an Adobe Commerce on cloud infrastructure project**:
 
-1. Download an application template from the [Magento Cloud repository][cloud-repo]. Be careful to select the branch that corresponds with the Commerce version.
+1. Download an application template from the [Cloud template repository][cloud-repo]. Be careful to select the branch that corresponds with the Commerce version.
 
 1. Optionally, you can clone the latest template.
 
@@ -35,7 +35,7 @@ An on-premises installation requires the stand-alone `magento/magento-cloud-dock
 
 **To install an Adobe Commerce on-premises project**:
 
-1. Create a project using [Composer][composer-install].
+1. Create a project using [Composer](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/composer.html#prerequisites).
 
    ```bash
     composer create-project --repository-url=https://repo.magento.com/ magento/project-enterprise-edition <install-directory-name>
@@ -51,7 +51,7 @@ An on-premises installation requires the stand-alone `magento/magento-cloud-dock
    composer require --no-update --dev magento/ece-tools magento/magento-cloud-docker
    ```
 
-1. Create the default configuration source file, [.magento.docker.yml](../configure/configuration-sources.md#unified-configuration) to build the Docker containers for the local environment.
+1. Create the default configuration source file—[.magento.docker.yml](../configure/configuration-sources.md#unified-configuration)—to build the Docker containers for the local environment.
 
    ```yaml
    name: magento
@@ -122,7 +122,7 @@ Before you use Cloud Docker for Commerce, you must update the `etc/hosts` file a
    curl -sL https://github.com/magento/magento-cloud-docker/releases/download/1.2.0/init-docker.sh | bash -s -- --php 7.4
    ```
 
-   If required, you can add options to the `init-docker.sh` initialization script to customize your Docker environment. Run the following command to see the available options:
+   If necessary, you can add options to the `init-docker.sh` initialization script to customize your Docker environment. Run the following command to see the available options:
 
    ```bash
    curl -sL https://github.com/magento/magento-cloud-docker/releases/download/1.1.1/init-docker.sh | bash -s -- --help
@@ -133,6 +133,5 @@ After you complete the installation, you can begin using the Docker environment.
 <!--Link definitions-->
 
 [cloud-repo]: https://github.com/magento/magento-cloud
-[compoer-install]: https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/composer.html
 [docker-repo]: https://github.com/magento/magento-cloud-docker
 [magento-creds]: https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/prerequisites/authentication-keys.html

--- a/src/pages/docker/setup/synchronize-data.md
+++ b/src/pages/docker/setup/synchronize-data.md
@@ -15,10 +15,10 @@ The Cloud Docker for Commerce `docker-build` command provides the `--sync-engine
 
 | Option          | Description         |
 | --------------- | ------------------- |
-| `native`        | Maps the current working directory to the `/app` directory on each volume, which provides direct access to the data without requiring any synchronization. The `native` option is the default and works for Linux hosts. On macOS or Windows hosts, this option results in extremely slow performance in the Docker environment. |
+| `native`        | Maps the current working directory to the `/app` directory on each volume, which provides direct access to the data without requiring any synchronization. The `native` option is the default and works for Linux hosts. On macOS or Windows hosts, this option results in reduced performance in the Docker environment. |
 | `manual-native` | Provides manual control over synchronization. Requires running manual commands. This option provides the best performance for macOS and Windows. |
-| `mutagen`       | Uses **Mutagen** for file synchronization. When you select Mutagen, you must [install Mutagen](https://mutagen.io/documentation/introduction/installation) on your host operating system before you [launch Docker in developer mode](../deploy/developer-mode.md). Use this option on macOS or Windows hosts. |
-| `docker-sync`   | **Deprecated in 1.2.3**: Uses **docker-sync** for file synchronization. When you select docker-sync, you must [install docker-sync](https://docker-sync.readthedocs.io/en/latest/#) on your host operating system before you [launch Docker in developer mode](../deploy/developer-mode.md). Use this option on macOS or Windows hosts. |
+| `mutagen`       | Uses **Mutagen** for file synchronization. When you select Mutagen, you must [install Mutagen](https://mutagen.io/documentation/introduction/installation) before you [launch Docker in developer mode](../deploy/developer-mode.md). Use this option on macOS or Windows hosts. |
+| `docker-sync`   | **Deprecated in 1.2.3**: Uses **docker-sync** for file synchronization. When you select docker-sync, you must [install docker-sync](https://docker-sync.readthedocs.io/en/latest/#) before you [launch Docker in developer mode](../deploy/developer-mode.md). Use this option on macOS or Windows hosts. |
 
 ### Native option
 
@@ -46,7 +46,7 @@ When you start Docker with the `native` file synchronization option, the current
 
 ### Mutagen and manual-native options
 
-On macOS or Windows systems, we recommend using the `mutagen` or `manual-native` file synchronization options. You can use these options in the `ece-docker build:compose` command by adding the option as the value for `--sync-engine`. For example:
+On macOS or Windows systems, Adobe recommends using the `mutagen` or `manual-native` file synchronization options. You can use these options in the `ece-docker build:compose` command by adding the option as the value for `--sync-engine`. For example:
 
 ```bash
 ./vendor/bin/ece-docker build:compose --mode="developer" --sync-engine="mutagen"

--- a/src/pages/docker/test/application-testing.md
+++ b/src/pages/docker/test/application-testing.md
@@ -5,12 +5,12 @@ description: Learn how to use the MFTF for Commerce application testing in the C
 
 # Application testing
 
-In a Cloud Docker development environment, you can use the [Magento Functional Testing Framework (MFTF)][MFTF docs] for application testing. In this environment, you run MFTF commands using the `mftf-command` ([CLI container command](../containers/cli.md#cli-container-commands)).
+In a Cloud Docker development environment, you can use the [Magento Functional Testing Framework (MFTF)][MFTF docs] for application testing.
 
-For example, the following command generates the MFTF tests:
+In this environment, you run MFTF commands using the `mftf-command` ([CLI container command](../containers/cli.md#cli-container-commands)). For example, the following command generates the MFTF tests:
 
 ```bash
-docker-compose run test mftf-command generate:tests --debug=none
+docker compose run test mftf-command generate:tests --debug=none
 ```
 
 <InlineAlert variant="info" slots="text"/>
@@ -61,7 +61,7 @@ Support for MFTF requires `magento/magento-cloud-docker` version 1.0 or later.
    ```
 
    ```bash
-   docker-compose run deploy bash -c "echo \"$CONFIG\" > /app/dev/tests/acceptance/.env"
+   docker compose run deploy bash -c "echo \"$CONFIG\" > /app/dev/tests/acceptance/.env"
    ```
 
    <!-- <InlineAlert variant="info" slots="text"/> -->
@@ -71,51 +71,51 @@ Support for MFTF requires `magento/magento-cloud-docker` version 1.0 or later.
 1. Disable the Magento settings that conflict with MFTF functionality.
 
    ```bash
-   docker-compose run deploy magento-command config:set admin/security/admin_account_sharing 1
+   docker compose run deploy magento-command config:set admin/security/admin_account_sharing 1
    ```
 
    ```bash
-   docker-compose run deploy magento-command config:set admin/security/use_form_key 0
+   docker compose run deploy magento-command config:set admin/security/use_form_key 0
    ```
 
    ```bash
-   docker-compose run deploy magento-command config:set web/secure/use_in_adminhtml 0
+   docker compose run deploy magento-command config:set web/secure/use_in_adminhtml 0
    ```
 
 1. Enable the Varnish cache for the Magento application.
 
    ```bash
-   docker-compose run deploy magento-command config:set  system/full_page_cache/caching_application 2 --lock-env
+   docker compose run deploy magento-command config:set  system/full_page_cache/caching_application 2 --lock-env
    ```
 
    ```bash
-   docker-compose run deploy magento-command setup:config:set  --http-cache-hosts=varnish
+   docker compose run deploy magento-command setup:config:set  --http-cache-hosts=varnish
    ```
 
 1. Clear the cache.
 
    ```bash
-   docker-compose run deploy magento-command cache:clean
+   docker compose run deploy magento-command cache:clean
    ```
 
 1. Generate MFTF tests.
 
    ```bash
-   docker-compose run test mftf-command build:project
+   docker compose run test mftf-command build:project
    ```
 
    ```bash
-   docker-compose run test mftf-command generate:tests --debug=none
+   docker compose run test mftf-command generate:tests --debug=none
    ```
 
 1. Run the generated tests.
 
    ```bash
-   docker-compose run test mftf-command run:test AdminLoginTest --debug=none
+   docker compose run test mftf-command run:test AdminLoginTest --debug=none
    ```
 
    ```bash
-   docker-compose run test mftf-command run:test AddProductBySkuWithEmptyQtyTest --debug=none
+   docker compose run test mftf-command run:test AddProductBySkuWithEmptyQtyTest --debug=none
    ```
 
 <!-- link definitions -->

--- a/src/pages/docker/test/blackfire.md
+++ b/src/pages/docker/test/blackfire.md
@@ -57,17 +57,17 @@ You must have a Blackfire license and account to use Blackfire with Adobe Commer
    -  Deploy Adobe Commerce in the Docker container.
 
       ```bash
-      docker-compose run --rm deploy cloud-deploy
+      docker compose run --rm deploy cloud-deploy
       ```
 
       ```bash
-      docker-compose run --rm deploy magento-command deploy:mode:set developer
+      docker compose run --rm deploy magento-command deploy:mode:set developer
       ```
 
    -  Run post-deploy hooks.
 
       ```bash
-      docker-compose run --rm deploy cloud-post-deploy
+      docker compose run --rm deploy cloud-post-deploy
       ```
 
    <!-- <InlineAlert variant="help" slots="text"/> -->
@@ -77,23 +77,23 @@ You must have a Blackfire license and account to use Blackfire with Adobe Commer
 1. Enable the Varnish cache for the Adobe Commerce application.
 
    ```bash
-   docker-compose run --rm deploy magento-command config:set system/full_page_cache/caching_application 2 --lock-env
+   docker compose run --rm deploy magento-command config:set system/full_page_cache/caching_application 2 --lock-env
    ```
 
    ```bash
-   docker-compose run --rm deploy magento-command setup:config:set  --http-cache-hosts=varnish
+   docker compose run --rm deploy magento-command setup:config:set  --http-cache-hosts=varnish
    ```
 
 1. Clear the cache.
 
    ```bash
-   docker-compose run --rm deploy magento-command cache:clean
+   docker compose run --rm deploy magento-command cache:clean
    ```
 
 1. Make sure that necessary containers are up and running.
 
    ```bash
-   docker-compose ps
+   docker compose ps
    ```
 
 **To use Blackfire.io for performance testing in Cloud Docker**:

--- a/src/pages/docker/test/code-testing.md
+++ b/src/pages/docker/test/code-testing.md
@@ -114,7 +114,7 @@ Add credentials to your Docker environment using any of the following methods:
 
 **To load credentials from the environment configuration file**:
 
-1. Run the following commands to write credentials to the `./.env` file.
+1. Run the following commands to write credentials to the `./.env` file:
 
    ```bash
    echo "REPO_USERNAME=your_public_key" >> ./.env

--- a/src/pages/docker/upgrade-docker-package.md
+++ b/src/pages/docker/upgrade-docker-package.md
@@ -5,11 +5,13 @@ description: Follow these steps to upgrade the Cloud Docker for Commerce package
 
 # Upgrade Cloud Docker package
 
-We recommend that you use the latest version of Cloud Docker for Commerce. The version requirement is specified in the `composer.json` file for your project. Use the following instructions for the upgrade process.
+It is a best practice to use the latest version of Cloud Docker for Commerce.
+
+The version requirement is specified in the `composer.json` file for your project. Use the following instructions for the upgrade process.
 
 <InlineAlert variant="info" slots="text"/>
 
-Cloud Docker for Commerce releases sometimes introduce changes to the format and options in the `docker-compose.yml` file. We recommend creating a backup of your existing `docker-compose.yml` file before upgrading so you can review the changes. If you have custom configurations that you want to preserve across builds, move them to the [`docker-compose.override.yml`](quick-reference.md#override-configuration) file before you rebuild or upgrade the Docker environment.
+Cloud Docker for Commerce releases sometimes introduce changes to the format and options in the `docker-compose.yml` file. Adobe recommends creating a backup of your existing `docker-compose.yml` file before upgrading so you can review the changes. If you have custom configurations that you want to preserve across builds, move them to the [`docker-compose.override.yml`](quick-reference.md#override-configuration) file before you rebuild or upgrade the Docker environment.
 
 **To update the Cloud Docker for Commerce package:**
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) provides a general cleanup for the Docker content. It fixes the following:

- Checked against Acrolinx for grammar, style, tone improvements
- Tended to the first sentence of each topic, since it has a special format following the page heading
- Fixed broken or outdated links
- Adjusted headings to improve page TOCs, especially when missing level
- corrected the `docker compose` commands to conform to latest use with Compose v2, [as noted in the Docker documentation](https://docs.docker.com/compose/reference/)
- Removed redundant information if noticed

Remaining tasks:
- [x] Add note about Docker compose version
- [x] Editorial review

