### PR TITLE
Typo: Execution instead of Extension

### DIFF
--- a/src/pages/docker/test/configure-xdebug.md
+++ b/src/pages/docker/test/configure-xdebug.md
@@ -117,7 +117,7 @@ You can debug any Adobe Commerce command or PHP script using the following steps
 
 **To debug CLI commands**:
 
-1. In your PhpStorm project, open the **Build, Extension, Deployment** > **Docker** panel, and then click `+` to add a Docker server and update the following settings:
+1. In your PhpStorm project, open the **Build, Execution, Deployment** > **Docker** panel, and then click `+` to add a Docker server and update the following settings:
 
    -  **Name**—Enter a name for the server, for example `Docker Cloud`.
    -  **Connect to Docker daemon with**—


### PR DESCRIPTION
The menu item in PHPStorm's config is Execution, not Extension. A simple typo :-)

## Purpose of this pull request

This pull request (PR) ...

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Commerce code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED.
If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add the link here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
-->
