### PR TITLE
Add validation for custom headers

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,9 +1,12 @@
-import remarkValidateLinks from 'remark-validate-links';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkLintFrontmatterSchema from 'remark-lint-frontmatter-schema';
+import remarkHeadingId from "remark-heading-id";
+import remarkValidateLinks from "remark-validate-links";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkLintFrontmatterSchema from "remark-lint-frontmatter-schema";
+import remarkLintNoDeadUrls from "remark-lint-no-dead-urls";
 
 const remarkConfig = {
 	plugins: [
+		remarkHeadingId,
 		remarkValidateLinks,
 		remarkFrontmatter,
 		[
@@ -11,13 +14,21 @@ const remarkConfig = {
 			{
 				schemas: {
 					/* One schema for many files */
-					'./.github/linters/metadata.schema.yml': [
+					"./.github/linters/metadata.schema.yml": [
 						/* Support glob patterns ———v */
-						'./src/pages/**/*.md',
+						"./src/pages/**/*.md",
 					],
 				},
 			},
 		],
+		[
+			remarkLintNoDeadUrls,
+			{
+				skipUrlPatterns: [
+					"https://www.php.net"
+				]
+			}
+		]
 	],
 };
 export default remarkConfig;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "remark-cli": "^10.0.1",
     "remark-frontmatter": "4.0.1",
+    "remark-heading-id": "^1.0.1",
     "remark-lint-frontmatter-schema": "^3.15.2",
     "remark-validate-links": "^11.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6754,6 +6754,7 @@ __metadata:
     react-dom: ^17.0.2
     remark-cli: ^10.0.1
     remark-frontmatter: 4.0.1
+    remark-heading-id: ^1.0.1
     remark-lint-frontmatter-schema: ^3.15.2
     remark-validate-links: ^11.0.2
   languageName: unknown
@@ -17314,6 +17315,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-heading-id@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "remark-heading-id@npm:1.0.1"
+  dependencies:
+    lodash: ^4.17.21
+    unist-util-visit: ^1.4.0
+  checksum: 20fd8072436280936dd76cf3a86d3e8e4f89bb4440863ea67d5c2ad27b74e858350aaf5a56a292bdb7f99c28fa823a83d8cfac87bfc410ebb39d23594d5905d8
+  languageName: node
+  linkType: hard
+
 "remark-lint-frontmatter-schema@npm:^3.15.2":
   version: 3.15.2
   resolution: "remark-lint-frontmatter-schema@npm:3.15.2"
@@ -20162,7 +20173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unist-util-visit@npm:^1.0.0, unist-util-visit@npm:^1.1.0, unist-util-visit@npm:^1.4.1":
+"unist-util-visit@npm:^1.0.0, unist-util-visit@npm:^1.1.0, unist-util-visit@npm:^1.4.0, unist-util-visit@npm:^1.4.1":
   version: 1.4.1
   resolution: "unist-util-visit@npm:1.4.1"
   dependencies:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a [remark-heading-id](https://github.com/imcuttle/remark-heading-id) plugin that allows validation of custom headers via remark-validate-links.

## Test

See https://github.com/AdobeDocs/commerce-admin-developer/pull/85
