### PR TITLE
Update initialize-docker.md

### DIFF
--- a/src/pages/docker/setup/initialize-docker.md
+++ b/src/pages/docker/setup/initialize-docker.md
@@ -123,7 +123,7 @@ Before you use Cloud Docker for Commerce, you must update the `etc/hosts` file a
 1. Install the template dependencies and add the default hostname to your `/etc/hosts` file.
 
    ```bash
-   curl -sL https://github.com/magento/magento-cloud-docker/releases/download/1.3.5/init-docker.sh | bash -s -- --php 8.2
+   curl -sL https://github.com/magento/magento-cloud-docker/releases/download/1.3.5/init-docker.sh | bash -s -- --php 8.2 --image 1.3.5
    ```
 
    If necessary, you can add options to the `init-docker.sh` initialization script to customize your Docker environment. Run the following command to see the available options:


### PR DESCRIPTION
Adding image version for PHP 8.2 else it will pick the default version defined 1.3.2 and throw an error "Image not found"

## Purpose of this pull request

This pull request (PR) will fix an issue of "**_docker: Error response from daemon: manifest for magento/magento-cloud-docker-php:8.2-cli-1.3.2 not found: manifest unknown: manifest unknown._**" while executing "`curl -sL https://github.com/magento/magento-cloud-docker/releases/download/1.3.5/init-docker.sh | bash -s -- --php 8.2"` command

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/cloud-tools/docker/setup/initialize-docker/#on-premises-projects

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-cloud-tools/blob/main/.github/CONTRIBUTING.md) for more information.
-->
